### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -88,7 +88,7 @@ get_version() {
   local __resultvar=$2
 
   version=$(curl -s "$url/Packages" | awk -v package="$package_name" '
-    $0 ~ "^Package: " package {found=1} 
+    $1 == "Package:" && $2 == package {found=1} 
     found && /^Version:/ {print $2; exit}
   ')
   eval $__resultvar="'$version'"


### PR DESCRIPTION
Fix row 91. It was causing this error:

$ curl -sS https://raw.githubusercontent.com/offici5l/MiTool/master/install.sh | bash

apt upgrade ...bash: line 81: unexpected EOF while looking for matching `"' ~ $